### PR TITLE
Configure GitHub Pages export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# static export output
+docs/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Your project is live at:
 
 **[https://vercel.com/mikemacri-9432s-projects/v0-options-dashboard-ui](https://vercel.com/mikemacri-9432s-projects/v0-options-dashboard-ui)**
 
+### GitHub Pages
+
+To serve the dashboard from GitHub Pages instead of the default README, run:
+
+```bash
+pnpm export
+git add -f docs
+git commit -m "chore: update docs"
+```
+
+The `export` script builds the static site into `docs` (including a `.nojekyll` file). The folder is git-ignored to avoid committing large artifacts by default, so force-add it when publishing to GitHub Pages.
+
 ## Build your app
 
 Continue building your app on:

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+const isGithubPages = Boolean(process.env.GITHUB_PAGES)
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
@@ -9,6 +11,13 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  ...(isGithubPages
+    ? {
+        output: 'export',
+        basePath: '/v1options-dashboard-ui',
+        trailingSlash: true,
+      }
+    : {}),
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "export": "rm -rf docs && GITHUB_PAGES=true next build && mv out docs && touch docs/.nojekyll"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- add missing Tabs UI component
- configure Next.js for GitHub Pages static export
- document export workflow and generate `docs` output
- remove binary build artifacts and ignore static export output

## Testing
- `pnpm export`


------
https://chatgpt.com/codex/tasks/task_e_68b5d504cc6c8331a420d91bf691a2dc